### PR TITLE
DM-39539: Clean up the API a little bit

### DIFF
--- a/src/vocutouts/handlers/external.py
+++ b/src/vocutouts/handlers/external.py
@@ -11,7 +11,11 @@ from safir.metadata import get_metadata
 from ..config import config
 from ..models.capabilities import Capabilities
 from ..models.index import Index
-from ..models.parameters import CutoutJob, CutoutJobCreate
+from ..models.parameters import (
+    CutoutAsyncJobCreate,
+    CutoutJob,
+    CutoutJobCreate,
+)
 from ..uws.dependencies import UWSFactory, uws_dependency
 from ..uws.handlers import add_uws_routes
 from ..uws.models import Availability
@@ -23,23 +27,16 @@ external_router = APIRouter()
 
 
 @external_router.get(
-    "/",
+    "",
     response_model=Index,
     response_model_exclude_none=True,
     summary="Application metadata",
+    description=(
+        "Metadata about the application, returned by a request for the root"
+        " of the external API."
+    ),
 )
 async def get_index() -> Index:
-    """GET ``/api/cutout/`` (the app's external root).
-
-    Customize this handler to return whatever the top-level resource of your
-    application should return. For example, consider listing key API URLs.
-    When doing so, also change or customize the response model in
-    `vocutouts.models.Index`.
-
-    By convention, the root of the external API includes a field called
-    ``metadata`` that provides the same Safir-generated metadata as the
-    internal root endpoint.
-    """
     metadata = get_metadata(
         package_name="ivoa-cutout-poc",
         application_name=config.name,
@@ -84,5 +81,6 @@ add_uws_routes(
     sync_prefix="/sync",
     async_prefix="/jobs",
     job_model=CutoutJob,
-    job_create_model=CutoutJobCreate,
+    job_sync_create_model=CutoutJobCreate,
+    job_async_create_model=CutoutAsyncJobCreate,
 )

--- a/src/vocutouts/models/parameters.py
+++ b/src/vocutouts/models/parameters.py
@@ -6,8 +6,15 @@ from typing import Any
 
 from pydantic import BaseModel, Field, validator
 
-from ..uws.models import Job, JobCreate
+from ..uws.models import AsyncJobCreate, Job, JobCreate
 from .stencils import CircleStencil, PolygonStencil, RangeStencil
+
+__all__ = [
+    "CutoutAsyncJobCreate",
+    "CutoutJob",
+    "CutoutJobCreate",
+    "CutoutParameters",
+]
 
 
 class CutoutParameters(BaseModel):
@@ -34,6 +41,12 @@ class CutoutJob(Job):
 
 
 class CutoutJobCreate(JobCreate):
-    """The corresponding job creation model."""
+    """The sync job creation model."""
+
+    parameters: CutoutParameters = Field(..., title="Job parameters")
+
+
+class CutoutAsyncJobCreate(AsyncJobCreate):
+    """The async job creation model."""
 
     parameters: CutoutParameters = Field(..., title="Job parameters")

--- a/src/vocutouts/uws/models.py
+++ b/src/vocutouts/uws/models.py
@@ -272,12 +272,36 @@ class JobCreate(GenericModel, Generic[T]):
 
     parameters: T = Field(..., title="Parameters of the job")
 
+    run_id: Optional[str] = Field(
+        None,
+        title="Opaque string provided by client",
+        description=(
+            "This field is intended for the client to add a unique identifier"
+            " to all jobs that are part of a single operation from the"
+            " perspective of the client. This may aid in tracing issues"
+            " through a complex system, or identifying which operation a job"
+            " is part of."
+        ),
+        example="processing-run-40",
+    )
+
+
+class AsyncJobCreate(GenericModel, Generic[T]):
+    """Information required to create a new async job.
+
+    Notes
+    -----
+    As with `JobCreate`, users of the UWS library therefore must define a
+    subclass of this class that redeclares ``parameters`` with a concrete
+    class inheriting from ``pydantic.BaseModel``, and then pass that derived
+    class into `~vocutouts.uws.handlers.add_uws_routes`.
+    """
+
+    parameters: T = Field(..., title="Parameters of the job")
+
     start: bool = Field(
         False,
         title="Automatically start job",
-        description=(
-            "Ignored for sync jobs, which are always automatically started"
-        ),
     )
 
     run_id: Optional[str] = Field(

--- a/tests/handlers/external_test.py
+++ b/tests/handlers/external_test.py
@@ -11,8 +11,8 @@ from vocutouts.config import config
 
 @pytest.mark.asyncio
 async def test_get_index(client: AsyncClient) -> None:
-    """Test ``GET /api/cutout/``"""
-    response = await client.get("/api/cutout/")
+    """Test ``GET /api/cutout``"""
+    response = await client.get("/api/cutout")
     assert response.status_code == 200
     data = response.json()
     metadata = data["metadata"]

--- a/tests/support/uws.py
+++ b/tests/support/uws.py
@@ -25,7 +25,7 @@ from vocutouts.uws.jobs import (
     uws_job_failed,
     uws_job_started,
 )
-from vocutouts.uws.models import ExecutionPhase, Job, JobCreate
+from vocutouts.uws.models import AsyncJobCreate, ExecutionPhase, Job, JobCreate
 from vocutouts.uws.policy import UWSPolicy
 from vocutouts.uws.schema import Job as SQLJob
 from vocutouts.uws.service import JobService
@@ -82,6 +82,12 @@ class TrivialJob(Job):
 
 
 class TrivialJobCreate(JobCreate):
+    """The corresponding job creation model."""
+
+    parameters: TrivialParameters = Field(..., title="Job parameters")
+
+
+class TrivialAsyncJobCreate(AsyncJobCreate):
     """The corresponding job creation model."""
 
     parameters: TrivialParameters = Field(..., title="Job parameters")

--- a/tests/uws/conftest.py
+++ b/tests/uws/conftest.py
@@ -37,6 +37,7 @@ from vocutouts.uws.handlers import add_uws_routes
 from vocutouts.uws.schema import Base
 
 from ..support.uws import (
+    TrivialAsyncJobCreate,
     TrivialJob,
     TrivialJobCreate,
     TrivialParameters,
@@ -75,7 +76,8 @@ async def app(
         sync_prefix="/sync",
         async_prefix="/jobs",
         job_model=TrivialJob,
-        job_create_model=TrivialJobCreate,
+        job_sync_create_model=TrivialJobCreate,
+        job_async_create_model=TrivialAsyncJobCreate,
     )
     uws_app.include_router(router)
     uws_broker.add_middleware(WorkerSession(uws_config))


### PR DESCRIPTION
Remove the default comment for the external root and remove the trailing slash. Rework the way sync and async jobs are created by the UWS layer so that the start parameter isn't present for sync jobs, avoiding the need to document that it's ignored.